### PR TITLE
Change pio and init_libs in installation from src

### DIFF
--- a/docs/installation/from_source.md
+++ b/docs/installation/from_source.md
@@ -29,10 +29,19 @@ To obtain the source code for a particular release, it can be downloaded from th
 
 ## Install:
 
+:::info
+
+If you installed platformio from Python pip, you may need to run `python3 -m platformio run` instead of `pio run`.
+
+:::
+
 ```
 # Init NFC libs
-bash init_nfc_libs.sh
+bash init_libs.sh
+
 pio run
+# OR python3 -m platformio run
+
 # To upload firmware
 pio run -t upload
 ```


### PR DESCRIPTION
I added a note for those installing platformio from Python, in which case they must use the python library, and cannot run `pio run`.

I changed the init_nfc_libs.sh to init_libs.sh as the filename has changed.